### PR TITLE
Hhandle empty title and date in ZoteroItem

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "nz.magnusso.zotero-link",
 	"app_min_version": "2.12",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"name": "Zotero Link",
 	"description": "Link Zotero entries in notes",
 	"author": "Jannes Magnusson",

--- a/src/zotero-item.ts
+++ b/src/zotero-item.ts
@@ -10,29 +10,29 @@ export class ZoteroItem {
 
     constructor(item) {
       this.key = item.key;
-      this.title = item.title;
-      this.date = item.date;
+      this.title = item.title || '';
+      this.date = item.date || '';
       this.creators = ZoteroItem.parseCreators(item.creators);
-  
+
       this.titleL = this.title ? item.title.toLowerCase() : '';
       this.creatorsL = this.creators.toLowerCase();
     }
-  
+
     static parseCreators(creators) {
       if (!creators) return '';
       return creators.filter(c => c.creatorType === 'author')
                      .map(c => `${c.firstName} ${c.lastName}`)
                      .join(', ');
     }
-  
+
     matches(query) {
       if (!query) return true;
-      
+
       return this.match(query, this.titleL) ||
              this.match(query, this.date) ||
              this.match(query, this.creatorsL)
     }
-  
+
     match(query, value) {
       return value ? value.indexOf(query) >= 0 : false;
     }


### PR DESCRIPTION
If the title of a Zotero item was empty, the sorting failed and the plugin showed an error. With this commit title and date, get a default value of an empty string "". 

Also pushed the version number to 1.0.1

Create plugin btw 😄 