### PR TITLE
Added ability to use citation styles

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "ts-prepare",
+			"problemMatcher": [],
+			"label": "npm: ts-prepare",
+			"detail": "npm run stopJop && npm run dist && npm run replace"
+		},
+		{
+			"type": "npm",
+			"script": "tsprepare",
+			"problemMatcher": [],
+			"label": "npm: tsprepare",
+			"detail": "npm run stopJop && npm run dist && npm run replace"
+		}
+	]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.1.0
+# 2.1.3
 
-- Added support for custom format link.
-- Removed `author` filter on item to include other type of creator.
+- Added a variable for <authorslastnames> which is a comma delineated string of author's last name
+- Added automatic creation of citations formatted in accordance to citation style from Zotero Citation Repository--Zotero >= 7 only
+- Added a plugin setting that accepts the name of a format form the Zotero Citation Repository (e.g. apa, chicago-author-date) 
+- Added a plugin setting to allow the customization of the autocomplete hint--Zotero >= 7 only
+- Added a plugin setting to allow the customization of the autocomplete hint sort order--Zotero >= 7 only
+- Added a plugin setting to allow the customization of the addition details to show with the auto complete hint--Zotero >= 7 only

--- a/README.md
+++ b/README.md
@@ -24,7 +24,15 @@ When having trouble using this plugin, please have a look down below to the FAQ.
 
 ### Custom Formatting
 
-Custom formattting of the text can be enabled from plugin settings.
+Custom formatting of the text can be enabled from plugin settings.
+
+| Setting   | Function |
+|---|---|
+| Citation Style | Accepts Zotero Citation Repository ids (e.g. apa, chicago-author-date, modern-language-association, ieee, american-medical-association) to allow for automatic generation of citations.   |
+| Custom Format| This allows you to use variables (see Available Variables) to customize to what the Zotero information appears in the document.  |
+| Custom Hint Format | This allows you to use variables (see Available Variables)to customize what you see in the autocomplete dropdown.  |
+| Custom Hint Details | This allows you to use variables (see Available Variables)to customize additional information that you want to see in the autocomplete dropdown. This will not influence sorting of the autocomplete hints.   |
+| Custom Hint Sorting | This allows you to use variables (see Available Variables)to customize sort order of the autocomplete dropdown hints. If left empty the Custom Hint Format will be used.  |
 
 #### Example
 
@@ -34,13 +42,14 @@ Custom formattting of the text can be enabled from plugin settings.
 | Markdown | `[Jannes Magnusson, 2024, *jannessm/joplin-zotero-link*](zotero://select/library/items/Q5U7SN82)[&#x1F517;](https://github.com/jannessm/joplin-zotero-link)`|
 | Editor | [Jannes Magnusson, 2024, *jannessm/joplin-zotero-link*](zotero://select/library/items/Q5U7SN82)[&#x1F517;](https://github.com/jannessm/joplin-zotero-link) |
 
-#### Available parameters
-| Key        | Description          |
+#### Available Variables
+| Variable        | Description          |
 |----------------|----------------------|
 | `<key>`        | Zotero key           |
 | `<zoterolink>` | Local zotero link `zotero://select/library/items/<key>` |
 | `<authors>`     |    All authors                  |
 |  `<authorfirst>`               |        First author |
+|  `<firtauthor>`               |        First author |
 |   `<title>`   |   Title |
 |  `<date>` | Date in local format         |
 |  `<date:YYYY-MM-DDTHH:mm:ss>` | Date formating using [dayjs](https://day.js.org/) |
@@ -54,6 +63,8 @@ Custom formattting of the text can be enabled from plugin settings.
 |  `<url>` | External url    |
 |  `<externallink>`   |  Give external link with icon 🔗 `[&#x1F517;](<url>)` |
 |  `<externaldoi>`   |  Give external DOI link with icon 🔗 `[&#x1F517;](<doilink>)` |
+|  `<citation>`   |  For Zotero >= 7, this returns a citation formatted based of the Citation Style plugin settings |
+|  `<barecitation>`   |  The same as `<citation>` but without the surrounding parentheses |
 
 ## FAQ
 
@@ -64,3 +75,12 @@ Custom formattting of the text can be enabled from plugin settings.
 ### No Zotero Data could be loaded
 
 - check if the port is correct under the plugin settings ([#3](https://github.com/jannessm/joplin-zotero-link/issues/3), [#4](https://github.com/jannessm/joplin-zotero-link/issues/4), [#6](https://github.com/jannessm/joplin-zotero-link/issues/6))
+
+### Autocomplete shows text nested in `<ol><li></li></ol>`
+- This may happen if you use the <citation> or <barecitation> variable but leave the Citation Style setting empty. This can be fixed by entering a valid citation style or changing the <citation> or <barecitation> variable to something else. Note that once this is corrected, it might take Joplin a few seconds to update the settings.
+
+### Autocomplete isn't showing up
+- This may happen if you use an invalid citation style. Check citation style name to make sure it is correct. Note that once this is corrected, it might take Joplin a few seconds to update the settings.
+
+### Citation isn't working
+- Make sure that you are using Zotero >= 7, this has not been implemented for Zotero server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joplin-plugin-zotero-link",
-  "version": "2.1.0",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joplin-plugin-zotero-link",
-      "version": "2.1.0",
+      "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.18.1",
@@ -22,6 +22,7 @@
         "copy-webpack-plugin": "^11.0.0",
         "fs-extra": "^10.1.0",
         "glob": "^8.0.3",
+        "prettier": "3.4.2",
         "tar": "^6.1.11",
         "ts-loader": "^9.3.1",
         "typescript": "^4.8.2",
@@ -8604,6 +8605,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-zotero-link",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "scripts": {
     "dist": "webpack --env joplin-plugin-config=buildMain && webpack --env joplin-plugin-config=buildExtraScripts && webpack --env joplin-plugin-config=createArchive",
     "prepare": "npm run dist",
@@ -21,6 +21,7 @@
     "copy-webpack-plugin": "^11.0.0",
     "fs-extra": "^10.1.0",
     "glob": "^8.0.3",
+    "prettier": "3.4.2",
     "tar": "^6.1.11",
     "ts-loader": "^9.3.1",
     "typescript": "^4.8.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,15 @@ joplin.plugins.register({
 			if (msg === 'getSettings') {
 				const port = await joplin.settings.value(SETTING.Port);
 				const cf = await joplin.settings.value(SETTING.CustomFormat);
+				const chf = await joplin.settings.value(SETTING.CustomHintFormat);
+				const cs = await joplin.settings.value(SETTING.CitationStyle);
+				const chs = await joplin.settings.value(SETTING.CustomHintSort);
                 return {
 					port: port,
-					customFormat: cf
+					customFormat: cf,
+					customHintFormat: chf,
+					citationStyle: cs,
+					customHintSort: chs, 
 				};
 			} else {
 				await dialogs.setHtml(error, `

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "nz.magnusso.zotero-link",
 	"app_min_version": "2.12",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"name": "Zotero Link",
 	"description": "Link Zotero entries in notes",
 	"author": "Jannes Magnusson",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,7 +3,11 @@ import { SettingItemType } from 'api/types';
 
 export enum SETTING {
 	Port = 'zotero-port',
-    CustomFormat = 'zotero-custom-format'
+    CustomFormat = 'zotero-custom-format',
+    CustomHintFormat = 'zotero-custom-hint-format',
+    CitationStyle = 'zotero-citation-style',
+    CustomHintSort = 'zotero-custom-hint-sort',
+    CustomHintDetails = 'zotero-custom-hint-formatdetails'
 };
 
 export const registerSettings = async () => {
@@ -22,13 +26,47 @@ export const registerSettings = async () => {
             type: SettingItemType.String,
             label: 'Port of Zotero 7 API',
         },
+        [SETTING.CitationStyle]: {
+            section: sectionName,
+            value: '',
+            public: true,
+            type: SettingItemType.String,
+            label: 'Citation Style',
+            description: 'Allows you to format citations using Zotero Style Repository. Examples: apa, chicago-author-date, modern-language-association, ieee, american-medical-association'
+        },
         [SETTING.CustomFormat]: {
             section: sectionName,
             value: '[<title>](<zoterolink>)',
             public: true,
             type: SettingItemType.String,
-            label: 'Custom format',
-            description: 'Customize the text links using variables such as <author>, <title> and <date>.'
+            label: 'Custom Format',
+            description: 'Customize the text links using variables such as <authors>, <title> and <date>.'
         },
+        [SETTING.CustomHintFormat]: {
+            section: sectionName,
+            value: '<authors>',
+            public: true,
+            type: SettingItemType.String,
+            label: 'Custom Hint Format',
+            description: 'Customize the hints shown when you use @Z using variables such as <authors>, <title> and <date>.'
+        },
+        [SETTING.CustomHintDetails]: {
+            section: sectionName,
+            value: '',
+            public: true,
+            type: SettingItemType.String,
+            label: 'Custom Hint Details',
+            description: 'Customize additional details you will see in your hints'
+        },
+        [SETTING.CustomHintSort]: {
+            section: sectionName,
+            value: '',
+            public: true,
+            type: SettingItemType.String,
+            label: 'Custom Hint Sort',
+            description: 'Customize the sort order of the autocomplete hints shown.'
+        },
+        
+        
     });
 };

--- a/src/zotero-item.ts
+++ b/src/zotero-item.ts
@@ -3,128 +3,148 @@ import { EditorView } from "@codemirror/view";
 import { Annotation, AnnotationType, ChangeSet, Text } from "@codemirror/state";
 import { Editor } from "codemirror";
 
-import * as dayjs from 'dayjs';
+import * as dayjs from "dayjs";
 
 export class ZoteroItem {
-    key: string;
+  key: string;
 
-    title: string;
-    titleL: string;
+  title: string;
+  titleL: string;
+  date: string;
+  creators: string;
+  creatorsLastnames: string;
+  creatorsLastnamesL: string;
+  creatorsL: string;
+  firstCreator: string;
+  publication: string;
+  publicationShort: string;
+  citation: string;
+  bareCitation: string;
+  doi: string;
+  url: string;
 
-    date: string;
+  customFormat;
+  customHintFormat;
+  customHintSort;
+  customHintDetails;
 
-    creators: string;
-    creatorsL: string;
-    creatorFirst: string;
+  constructor(item, customFormat, customHintFormat, customHintSort, customHintDetails) {
+    this.key = item.key;
 
-    publication: string;
-    publicationShort: string;
+    this.title = item.title || "";
+    this.titleL = this.title ? item.title.toLowerCase() : "";
 
-    doi: string;
-    url: string;
+    this.date = item.date || "";
 
-    customFormat;
+    this.creators = ZoteroItem.parseCreators(item.creators);
+    this.creatorsL = this.creators.toLowerCase();
+    this.firstCreator = ZoteroItem.parseFirstCreator(item.creators);
+    this.creatorsLastnames = ZoteroItem.parseCreatorLastnames(item.creators);
+    this.creatorsLastnamesL = this.creatorsLastnames.toLowerCase();
+    this.publication = item.publicationTitle || "";
+    this.publicationShort = item.journalAbbreviation || "";
 
-    constructor(item, customFormat) {
-      this.key = item.key;
+    this.citation = item.citation || "";
+    this.bareCitation = this.citation.replace(/[()]/g, "") || "";
 
-      this.title = item.title || '';
-      this.titleL = this.title ? item.title.toLowerCase() : '';
+    this.doi = item.DOI || "";
+    this.url = item.url || "";
 
-      this.date = item.date || '';
-
-      this.creators = ZoteroItem.parseCreators(item.creators);
-      this.creatorsL = this.creators.toLowerCase();
-      this.creatorFirst = ZoteroItem.parseFirstCreator(item.creators);
-
-      this.publication = item.publicationTitle || '';
-      this.publicationShort = item.journalAbbreviation || '';
-
-      this.doi = item.DOI || '';
-      this.url = item.url || '';
-
-      this.customFormat = customFormat;
-    }
-
-    static parseCreators(creators) {
-      if (!creators) return '';
-      return creators.map(c => `${c.firstName} ${c.lastName}`)
-                     .join(', ');
-    }
-
-    static parseFirstCreator(creators) {
-      if (!creators) return '';
-      return creators.map(c => `${c.firstName} ${c.lastName}`)[0];
-    }
-
-    matches(query) {
-      if (!query) return true;
-
-      return this.match(query, this.titleL) ||
-             this.match(query, this.date) ||
-             this.match(query, this.creatorsL)
-    }
-
-    match(query, value) {
-      return value ? value.indexOf(query) >= 0 : false;
-    }
-
-    getHint(): Completion {
-      return {
-        label: 'z@' + this.titleL + this.creatorsL + this.date,
-        displayLabel: this.title,
-        detail: this.creators + ' ' + this.date,
-        apply: this.apply.bind(this)
-      };
-    }
-
-    two_digit_str_from_int(i: number): string {
-      if (i > 99) return i.toString();
-      return ("0" + i).slice(-2)
-    }
-
-    format(customFormat: string) {
-      let f = customFormat;
-      let date = new Date(this.date);
-      f = f.replace("<key>", this.key);
-      f = f.replace("<zoterolink>", `zotero://select/library/items/${this.key}`);
-      f = f.replace("<authors>", this.creators);
-      f = f.replace("<authorfirst>", this.creatorFirst)
-      f = f.replace("<title>", this.title);
-      f = f.replace("<date>", date.toLocaleDateString(undefined));
-      f = f.replace("<year>", date.toLocaleDateString(undefined, {year: "numeric"}));
-      f = f.replace("<month>", date.toLocaleDateString("en-US", {month: "long"}));
-      f = f.replace("<monthlocal>", date.toLocaleDateString(undefined, {month: "long"}))
-      f = f.replace("<publication>", this.publication);
-      f = f.replace("<publicationshort>", this.publicationShort);
-      f = f.replace("<doi>", this.doi);
-      f = f.replace("<doiurl>", `https://doi.org/${this.doi}`);
-      f = f.replace("<url>", this.url);
-      f = f.replace("<externallink>", `[&#x1F517;](${this.url})`);
-      f = f.replace("<externaldoi>", `[&#x1F517;](https://doi.org/${this.doi})`);
-
-      // Parse date with regex and dayjs library
-      const date_re = /<date:([^>]*)>/gm;
-      let tf = f; // Store the format to iterate while replacing date
-      let d_format;
-      while((d_format = date_re.exec(f)) !== null) {
-        tf = tf.replace(d_format[0], dayjs(date).format(d_format[1]).toString());
-      }
-      return tf;
-    }
-
-    apply(view: EditorView, completion: Completion, from: number, to: number) {
-      const replacement = this.format(this.customFormat);
-
-      const replaceTransaction = view.state.update({
-        changes: {
-          from: from-2,
-          to,
-          insert: replacement
-        },
-        annotations: pickedCompletion.of(completion)
-      });
-
-      view.dispatch(replaceTransaction);
-    }
+    this.customFormat = customFormat || this.title || this.creatorsLastnames;
+    this.customHintFormat = customHintFormat;
+    this.customHintSort = customHintSort;
+    this.customHintDetails = customHintDetails || "";
   }
+
+  static parseCreators(creators) {
+    if (!creators) return "";
+    return creators.map((c) => `${c.firstName} ${c.lastName}`).join(", ");
+  }
+
+  static parseFirstCreator(creators) {
+    if (!creators) return "";
+    return creators.map((c) => `${c.firstName} ${c.lastName}`)[0];
+  }
+  static parseCreatorLastnames(creators) {
+    if (!creators) return "";
+    return creators.map((c) => `${c.lastName}`).join(", ");
+  }
+  matches(query) {
+    if (!query) return true;
+
+    return (
+      this.match(query, this.titleL) ||
+      this.match(query, this.date) ||
+      this.match(query, this.creatorsL)
+    );
+  }
+
+  match(query, value) {
+    return value ? value.indexOf(query) >= 0 : false;
+  }
+  
+  getHint(): Completion {
+    let myHint = this.format(this.customHintFormat) || this.format(this.customFormat)
+    return {
+      label: 'z@'+this.format(this.customHintSort),
+      displayLabel: this.format(this.customHintFormat),
+      detail: this.format(this.customHintDetails),
+      apply: this.apply.bind(this),
+    };
+  }
+
+  two_digit_str_from_int(i: number): string {
+    if (i > 99) return i.toString();
+    return ("0" + i).slice(-2);
+  }
+
+  format(userCustomFormat: string) {
+    let f = userCustomFormat;
+    let date = new Date(this.date);
+    f = f.replace("<key>", this.key);
+    f = f.replace("<zoterolink>", `zotero://select/library/items/${this.key}`);
+    f = f.replace("<authors>", this.creators);
+    f = f.replace("<authorfirst>", this.firstCreator);
+    f = f.replace("<firstauthor>", this.firstCreator);
+    f = f.replace("<authorslastnames>", this.creatorsLastnames);
+    f = f.replace("<title>", this.title);
+    f = f.replace("<date>", date.toLocaleDateString(undefined));
+    f = f.replace("<year>", date.toLocaleDateString(undefined, { year: "numeric" }),);
+    f = f.replace("<month>",date.toLocaleDateString("en-US", { month: "long" }),);
+    f = f.replace("<monthlocal>",date.toLocaleDateString(undefined, { month: "long" }),);
+    f = f.replace("<publication>", this.publication);
+    f = f.replace("<publicationshort>", this.publicationShort);
+    f = f.replace("<doi>", this.doi);
+    f = f.replace("<doiurl>", `https://doi.org/${this.doi}`);
+    f = f.replace("<url>", this.url);
+    f = f.replace("<externallink>", `[&#x1F517;](${this.url})`);
+    f = f.replace("<externaldoi>", `[&#x1F517;](https://doi.org/${this.doi})`);
+    if (this.citation) {
+      f = f.replace("<citation>", this.citation);
+      f = f.replace("<barecitation>", this.bareCitation);
+    }
+    // Parse date with regex and dayjs library
+    const date_re = /<date:([^>]*)>/gm;
+    let tf = f; // Store the format to iterate while replacing date
+    let d_format;
+    while ((d_format = date_re.exec(f)) !== null) {
+      tf = tf.replace(d_format[0], dayjs(date).format(d_format[1]).toString());
+    }
+    return tf;
+  }
+
+  apply(view: EditorView, completion: Completion, from: number, to: number) {
+    const replacement = this.format(this.customFormat);
+
+    const replaceTransaction = view.state.update({
+      changes: {
+        from: from - 2,
+        to,
+        insert: replacement,
+      },
+      annotations: pickedCompletion.of(completion),
+    });
+
+    view.dispatch(replaceTransaction);
+  }
+}

--- a/src/zotero-link.ts
+++ b/src/zotero-link.ts
@@ -9,6 +9,7 @@ module.exports = {
                 if (!value) return;
                 const zq = new ZoteroQuery(context, cm);
                 
+                 
                 try {
                     CodeMirror.addExtension([
                         CodeMirror.joplinExtensions.completionSource(
@@ -31,7 +32,8 @@ module.exports = {
         return {
             plugin,
             codeMirrorOptions: {
-                'zoteroLink': true
+                'zoteroLink': true,
+                
             },
             assets: () => {
                 return [

--- a/src/zotero-query.ts
+++ b/src/zotero-query.ts
@@ -5,137 +5,200 @@ import { ZoteroItem } from "./zotero-item";
 import { CompletionContext, startCompletion } from "@codemirror/autocomplete";
 
 interface ChangePos {
-    line: any;
-    ch: any;
+  line: any;
+  ch: any;
 }
 
 interface Change {
-    from: ChangePos;
-    to: ChangePos;
+  from: ChangePos;
+  to: ChangePos;
 }
 
-const COMMAND = 'z@';
+const COMMAND = "z@";
 
 export class ZoteroQuery {
-    start: ChangePos;
-    change: Change;
-    zoteroItems: ZoteroItem[] = [];
-    filteredItems: ZoteroItem[] = [];
-    timeout: NodeJS.Timeout | undefined;
+  start: ChangePos;
+  change: Change;
+  zoteroItems: ZoteroItem[] = [];
+  filteredItems: ZoteroItem[] = [];
+  timeout: NodeJS.Timeout | undefined;
+  settings: { customFormat: ""; customHintFormat: ""; citationStyle: "", customHintSort: "", customHintDetails: "" };
 
-    constructor(private context, private cm) {
-        this.loadData().then(items => this.zoteroItems = items);
-    }
+  constructor(
+    private context,
+    private cm,
+  ) {
+    this.loadData().then((items) => (this.zoteroItems = items));
+  }
 
-    getCompletions() {
-        const that = this;
-        return (context: CompletionContext) => {
-            // reload data in background
-            that.loadData().then(items => that.zoteroItems = items);
-            let word = context.matchBefore(/\S+/);
-
-            if (!word || word.from == word.to || !word.text.startsWith('z@'))
-                return null;
-
-            return {
-                from: word.from + 2,
-                options: that.zoteroItems.map(item => item.getHint())
-            }  
-        }
-    }
-
-    query(query: string) {
-        if (!this.zoteroItems) {
-            return [];
-        }
-
-        query = query.toLowerCase();
-        this.filteredItems = this.zoteroItems.filter(item => item.matches(query));
-
-        return this.filteredItems.map(item => item.getHint());
-    }
-
-    async loadData() {
-        const settings = await this.context.postMessage('getSettings');
-
-        let data;
-
-        data = await this.tryZotero7(settings.port);
-
-        // zotero api is not working. Try to use zotserver
-        if (!data) {
-            data = await this.tryZotServer(settings.port);
-        }
-
-        if (!!data) {
-            data = data.filter(item => item.itemType !== 'attachment' && item.itemType !== 'note')
-                .map(item => new ZoteroItem(item, settings.customFormat));
+  getCompletions() {
+    const that = this;
+    return (context: CompletionContext) => {
+      // reload data in background
+      that.loadData().then((items) => (that.zoteroItems = items)); 
     
-            data.sort((a: ZoteroItem, b: ZoteroItem) => a.title.localeCompare(b.title));
-            return data;
-        } else {
-            this.context.postMessage({
-                title: 'Loading Zotero data failed.',
-                description: 'Data could not be loaded from Zotero. Please check if Zotero is running with the correct port set in your settings. Otherwise a broken reference in your library could be an issue. Please have a look at existing github issues to find more help.'
-            });
+      let word = context.matchBefore(/\S+/);
 
-            return [];
-        }
+      if (!word || word.from == word.to || !word.text.startsWith("z@"))
+        return null;
+      let sortedOptions = that.zoteroItems.map((item) => item.getHint())
+      // sortedOptions.sort((a,b) => a.displayLabel > b.displayLabel ? 1 : -1)
+     
+      return {
+        from: word.from + 2,
+        options: sortedOptions,
+        filter: true,
+      };
+    };
+  }
+
+  query(query: string) {
+    if (!this.zoteroItems) {
+      return [];
     }
 
-    async tryZotero7(port: string){
-        const query = new URLSearchParams({
-            itemType: '-attachment',
-            q: ''
-        }).toString();
-
-        try {
-            const res = await fetch(`http://localhost:${port}/api/users/0/items?${query}`, {
-                method: 'get',
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
-
-            if (res.status === 500) {
-                this.context.postMessage({
-                    title: 'Zotero API not working',
-                    description: res.body
-                });
-                return;
-            }
+    query = query.toLowerCase();
+    this.filteredItems = this.zoteroItems.filter((item) => item.matches(query));
+    let hints= this.filteredItems.map((item) => item.getHint());
     
-            const data = await res.json();
-            return data.map(item => item.data);
-        } catch (err) { }
+    return hints
+  }
+
+  async loadData() {
+    const settings = await this.context.postMessage("getSettings");
+    this.settings = settings;
+    let data;
+
+    data = await this.tryZotero7(settings.port, true);
+    // trys without citation if citation style is malformed or invalid
+    if (!data) {
+      data = await this.tryZotero7(settings.port, false);
     }
 
-    async tryZotServer(port: string) {
-        try {
-            const res = await fetch(`http://localhost:${port}/zotserver/search`, {
-                method: 'post',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify([{
-                    condition: 'quicksearch-everything',
-                    value: ''
-                }])
-            });
-
-            if (res.status === 500) {
-                this.context.postMessage({
-                    title: 'Zotero API not working',
-                    description: res.body
-                });
-                return;
-            }
-            
-            return await res.json();
-
-        } catch (err) {
-            return;
-        }
-
+    // zotero api is not working. Try to use zotserver
+    if (!data) {
+      data = await this.tryZotServer(settings.port);
     }
+
+    if (!!data) {
+    
+        
+      data = data
+        .filter(
+          (item) => item.itemType !== "attachment" && item.itemType !== "note",
+        )
+        .map(
+          (item) =>
+            new ZoteroItem(
+              item,
+              settings.customFormat,
+              settings.customHintFormat,
+              settings.customHintSort,
+              settings.customHintDetails,
+            ),
+        );
+
+        // data.sort((a,b) => a.citation > b.citation ? 1 : -1)
+    
+        data.sort((a:ZoteroItem,b:ZoteroItem) => a.citation > b.citation ? 1 : -1)
+     
+      return data;
+    } else {
+      this.context.postMessage({
+        title: "Loading Zotero data failed.",
+        description:
+          "Data could not be loaded from Zotero. Please check if Zotero is running with the correct port set in your settings. Otherwise a broken reference in your library could be an issue. Please have a look at existing github issues to find more help.",
+      });
+
+      return [];
+    }
+  }
+
+  async tryZotero7(port: string, allowCite: boolean) {
+    const query = new URLSearchParams({
+      itemType: "-attachment",
+      q: "",
+    }).toString();
+
+    // SORT ITEMS
+    // dateAdded, dateModified, title,
+    // creator, itemType, date, publisher,
+    // publicationTitle, journalAbbreviation,
+    // language, accessDate, libraryCatalog,
+    // callNumber, rights, addedBy, numItem
+
+    // SORT DIRECTION
+    // asc, desc
+   
+    let queryInclude = "";
+    let citationStyle = "";
+    if (allowCite) {
+      // let capture = this.settings.citationStyle.match(/\<citation:([a-zA-Z0-9-]+)\>/);
+
+      citationStyle = "style=" + this.settings.citationStyle.trim();
+
+      if (citationStyle) {
+        queryInclude = "include=data,citation";
+      }
+      //  `http://localhost:${port}/api/users/0/items?${query}&${querySort}&${queryInclude}&${citationStyle}
+    }
+    let fetchURL = `http://localhost:${port}/api/users/0/items?${query}&${queryInclude}&${citationStyle}`;
+    try {
+      const res = await fetch(fetchURL, {
+        method: "get",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (res.status === 500) {
+        this.context.postMessage({
+          title: "Zotero API not working",
+          description: res.body,
+        });
+        return;
+      }
+
+      const data = await res.json();
+      //    this suld only be run if there are citations
+
+      if (data[0].hasOwnProperty("citation")) {
+        data.forEach((item) => {
+          // Move the citation into the data object
+          item.data.citation = item.citation;
+        });
+      }
+      data.sort((a,b) => a.citation > b.citation ? 1 : -1)
+      return data.map((item) => item.data);
+    } catch (err) {}
+  }
+
+  async tryZotServer(port: string) {
+    try {
+      const res = await fetch(`http://localhost:${port}/zotserver/search`, {
+        method: "post",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify([
+          {
+            condition: "quicksearch-everything",
+            value: "",
+          },
+        ]),
+      });
+
+      if (res.status === 500) {
+        this.context.postMessage({
+          title: "Zotero API not working",
+          description: res.body,
+        });
+        return;
+      }
+
+      return await res.json();
+    } catch (err) {
+      return;
+    }
+  }
 }


### PR DESCRIPTION
The changes allow a formatted citation to be added to the ZoteroItem class. This citation is formatted using any of the citation styles used by Zotero. I added a plugin setting that allows users to enter the id of the Zotero citation style (e.g. apa, chicago-author-date). I also added two variables to allow users to indicate that that want to use the citation style. The <citation> variable returns the standard formatted citation, e.g. (Shagott, 2022), and the <barecitation> variable strips the parentheses, e.g. Shagott, 2022.

Additionally, I added a plugin settings that allow users to format the autocomplete hint (displayLabel), the additional information in the autocomplete hint (detail), and the sort order(label). All of these settings can use the variables available to the Custom Format setting
