### PR TITLE
Fix: load Zotero data from the plugin process

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,109 @@
 import joplin from 'api';
 import { ContentScriptType } from 'api/types';
+import * as http from 'http';
 
 import { registerSettings, SETTING } from './settings';
+
+interface ZoteroSettings {
+	port: string;
+	customFormat: string;
+}
+
+interface JsonRequestOptions {
+	method?: 'GET' | 'POST';
+	headers?: Record<string, string>;
+	body?: string;
+}
+
+async function getSettings(): Promise<ZoteroSettings> {
+	const port = await joplin.settings.value(SETTING.Port);
+	const customFormat = await joplin.settings.value(SETTING.CustomFormat);
+
+	return {
+		port: String(port || '23119').trim() || '23119',
+		customFormat: String(customFormat || '[<title>](<zoterolink>)'),
+	};
+}
+
+async function requestJson(url: string, options: JsonRequestOptions = {}): Promise<any | undefined> {
+	return new Promise<any | undefined>((resolve) => {
+		try {
+			const req = http.request(url, {
+				method: options.method || 'GET',
+				headers: options.headers || {},
+			}, (res) => {
+				let body = '';
+				res.setEncoding('utf8');
+				res.on('data', chunk => body += chunk);
+				res.on('error', () => resolve(undefined));
+				res.on('aborted', () => resolve(undefined));
+				res.on('end', () => {
+					const statusCode = res.statusCode || 0;
+					if (statusCode < 200 || statusCode >= 300) {
+						resolve(undefined);
+						return;
+					}
+
+					try {
+						resolve(body ? JSON.parse(body) : undefined);
+					} catch {
+						resolve(undefined);
+					}
+				});
+			});
+
+			req.on('error', () => resolve(undefined));
+
+			if (options.body) {
+				req.write(options.body);
+			}
+
+			req.end();
+		} catch {
+			resolve(undefined);
+		}
+	});
+}
+
+async function tryZotero7(settings: ZoteroSettings) {
+	const query = new URLSearchParams({
+		itemType: '-attachment',
+		q: '',
+	}).toString();
+
+	const data = await requestJson(`http://localhost:${settings.port}/api/users/0/items?${query}`, {
+		headers: {
+			'Accept': 'application/json',
+			'Zotero-API-Version': '3',
+		},
+	});
+
+	if (!Array.isArray(data)) {
+		return undefined;
+	}
+
+	return data.map(item => item && item.data).filter(Boolean);
+}
+
+async function tryZotServer(settings: ZoteroSettings) {
+	const data = await requestJson(`http://localhost:${settings.port}/zotserver/search`, {
+		method: 'POST',
+		headers: {
+			'Accept': 'application/json',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify([{
+			condition: 'quicksearch-everything',
+			value: '',
+		}]),
+	});
+
+	return Array.isArray(data) ? data : undefined;
+}
+
+async function loadZoteroData(settings: ZoteroSettings) {
+	return await tryZotero7(settings) || await tryZotServer(settings);
+}
 
 joplin.plugins.register({
 	onStart: async function() {
@@ -22,11 +124,12 @@ joplin.plugins.register({
 		await joplin.contentScripts.onMessage(scriptId, async (msg) => {
 
 			if (msg === 'getSettings') {
-				const port = await joplin.settings.value(SETTING.Port);
-				const cf = await joplin.settings.value(SETTING.CustomFormat);
-                return {
-					port: port,
-					customFormat: cf
+				return await getSettings();
+			} else if (msg && msg.type === 'loadZoteroData') {
+				const settings = await getSettings();
+				return {
+					items: await loadZoteroData(settings),
+					customFormat: settings.customFormat,
 				};
 			} else {
 				await dialogs.setHtml(error, `

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import joplin from 'api';
 import { ContentScriptType } from 'api/types';
-import * as http from 'http';
+import { request } from 'http';
 
 import { registerSettings, SETTING } from './settings';
 
@@ -28,7 +28,7 @@ async function getSettings(): Promise<ZoteroSettings> {
 async function requestJson(url: string, options: JsonRequestOptions = {}): Promise<any | undefined> {
 	return new Promise<any | undefined>((resolve) => {
 		try {
-			const req = http.request(url, {
+			const req = request(url, {
 				method: options.method || 'GET',
 				headers: options.headers || {},
 			}, (res) => {

--- a/src/zotero-query.ts
+++ b/src/zotero-query.ts
@@ -1,5 +1,3 @@
-import { start } from "repl";
-import { SETTING } from "./settings";
 import { ZoteroItem } from "./zotero-item";
 
 import { CompletionContext, startCompletion } from "@codemirror/autocomplete";
@@ -56,20 +54,15 @@ export class ZoteroQuery {
     }
 
     async loadData() {
-        const settings = await this.context.postMessage('getSettings');
+        const response = await this.context.postMessage({
+            type: 'loadZoteroData'
+        });
+        const customFormat = response && response.customFormat ? response.customFormat : '[<title>](<zoterolink>)';
+        let data = response && response.items;
 
-        let data;
-
-        data = await this.tryZotero7(settings.port);
-
-        // zotero api is not working. Try to use zotserver
-        if (!data) {
-            data = await this.tryZotServer(settings.port);
-        }
-
-        if (!!data) {
+        if (Array.isArray(data)) {
             data = data.filter(item => item.itemType !== 'attachment' && item.itemType !== 'note')
-                .map(item => new ZoteroItem(item, settings.customFormat));
+                .map(item => new ZoteroItem(item, customFormat));
 
             data.sort((a: ZoteroItem, b: ZoteroItem) => a.title.localeCompare(b.title));
             return data;
@@ -81,65 +74,9 @@ export class ZoteroQuery {
                 title: '⚠️ Data could not be loaded from Zotero.\nPlease check if Zotero is running with the correct port set in your settings.\nOtherwise a broken reference in your library could be an issue.\nPlease have a look at existing github issues to find more help.',
                 key: '__zotero_data_error__',
                 creators: []
-            }, settings.customFormat);
+            }, customFormat);
 
             return [errorItem];
         }
-    }
-
-    async tryZotero7(port: string) {
-        const query = new URLSearchParams({
-            itemType: '-attachment',
-            q: ''
-        }).toString();
-
-        try {
-            const res = await fetch(`http://localhost:${port}/api/users/0/items?${query}`, {
-                method: 'get',
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
-
-            if (res.status === 500) {
-                this.context.postMessage({
-                    title: 'Zotero API not working',
-                    description: res.body
-                });
-                return;
-            }
-
-            const data = await res.json();
-            return data.map(item => item.data);
-        } catch (err) { }
-    }
-
-    async tryZotServer(port: string) {
-        try {
-            const res = await fetch(`http://localhost:${port}/zotserver/search`, {
-                method: 'post',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify([{
-                    condition: 'quicksearch-everything',
-                    value: ''
-                }])
-            });
-
-            if (res.status === 500) {
-                this.context.postMessage({
-                    title: 'Zotero API not working',
-                    description: res.body
-                });
-                return;
-            }
-
-            return await res.json();
-
-        } catch (err) {
-            return;
-        }
-
     }
 }


### PR DESCRIPTION
Fixes #36.

## Problem

Zotero Link currently loads library data by calling Zotero's local API directly from its CodeMirror content script. In affected Joplin and Zotero versions, that request fails even though Zotero is running and its local API is available. The plugin then shows the "Data could not be loaded from Zotero" completion item.

The [official Zotero Local API documentation](https://www.zotero.org/support/dev/web_api/v3/local_api) states that clients can pass `0` as the user ID for the locally logged-in user, so a new Zotero user ID setting is not needed.

## Solution

Run the existing local API requests in the main Joplin plugin process using Node HTTP, then pass the returned items to the CodeMirror content script through Joplin's message API.

This keeps the existing endpoints:

- Zotero 7 and later: `/api/users/0/items`
- Zotero 6 and earlier: `/zotserver/search`

It also preserves the configured port, custom link format, item filtering, sorting, and existing failure warning.

## Testing

- Built the plugin with `npm run dist`
- Ran `git diff --check`
- Smoke-tested `/api/users/0/items` with Zotero 9.0.5: HTTP 200 with 40 item records
